### PR TITLE
fix(interview): [정은선] account 필드 조회 오류 수정 및 account_id 기반 조회로 변경

### DIFF
--- a/interview/repository/interview_repository.py
+++ b/interview/repository/interview_repository.py
@@ -19,8 +19,8 @@ class InterviewRepository(ABC):
         pass
 
     @abstractmethod
-    def findInterviewByAccount(self, account, page: int, pageSize: int) -> List[object]:
-        """특정 계정에 해당하는 인터뷰 목록을 반환합니다. 페이지네이션 적용"""
+    def findInterviewByAccount(self, account_id: int, page: int, pageSize: int) -> List[object]:
+        """특정 계정(account_id)에 해당하는 인터뷰 목록을 반환합니다. 페이지네이션 적용"""
         pass
 
     @abstractmethod

--- a/interview/repository/interview_repository_impl.py
+++ b/interview/repository/interview_repository_impl.py
@@ -42,15 +42,15 @@ class InterviewRepositoryImpl(InterviewRepository):
         except Interview.DoesNotExist:
             return None
 
-    def findInterviewByAccount(self, account, page: int, pageSize: int) -> models.QuerySet:
+    def findInterviewByAccount(self, account_id: int, page: int, pageSize: int) -> models.QuerySet:
         """특정 계정에 해당하는 인터뷰 목록 조회 (페이지네이션 적용)"""
-        interviews = Interview.objects.filter(account=account).order_by("-created_at")
+        interviews = Interview.objects.filter(account_id=account_id).order_by("-created_at")
         paginator = Paginator(interviews, pageSize)
         try:
-            page = paginator.page(page)
+            page_obj = paginator.page(page)   # ✅ page 변수 충돌 방지
         except EmptyPage:
-            page = paginator.page(paginator.num_pages)
-        return page
+            page_obj = paginator.page(paginator.num_pages)
+        return page_obj
 
     def deleteById(self, interviewId: int) -> bool:
         """인터뷰 ID로 인터뷰 삭제"""

--- a/interview/service/interview_service.py
+++ b/interview/service/interview_service.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 class InterviewService(ABC):
 
     @abstractmethod
-    def createInterview(self, accountId, jobCategory, experienceLevel,projectExperience,academicBackground,techStack, companyName):
+    def createInterview(self, accountId, jobCategory, experienceLevel, projectExperience, academicBackground, techStack, companyName):
         pass
 
     @abstractmethod
@@ -16,7 +16,7 @@ class InterviewService(ABC):
         pass
 
     @abstractmethod
-    def saveQuestion(self, interview_id: int, question: str) -> bool:
+    def saveQuestion(self, interview_id: int, question: str) -> int | None:
         pass
 
     @abstractmethod

--- a/interview/service/interview_service_impl.py
+++ b/interview/service/interview_service_impl.py
@@ -80,7 +80,8 @@ class InterviewServiceImpl(InterviewService):
                     "id": interview.id,
                     "topic": interview.topic,
                     "created_at": interview.created_at,
-                    # "yearsOfExperience": interview.experience_level  # 필요하다면 변환
+                    "status": interview.status,  # ✅ 추가
+                    # "yearsOfExperience": interview.experience_level
                 }
                 for interview in paginatedInterviewList
             ]

--- a/interview/service/interview_service_impl.py
+++ b/interview/service/interview_service_impl.py
@@ -1,4 +1,3 @@
-from django.core.paginator import Paginator
 from account.repository.account_repository_impl import AccountRepositoryImpl
 from interview.entity.interview import Interview
 from interview.entity.interview_answer import InterviewAnswer
@@ -25,57 +24,63 @@ class InterviewServiceImpl(InterviewService):
             cls.__instance = cls()
         return cls.__instance
 
-                                                                        # 일단 첫 질문은 고정이라 많은 정보 필요X
-    def createInterview(self, accountId, jobCategory, experienceLevel, projectExperience, academicBackground,techStack, companyName): #,projectExperience, academicBackground, techStack):
-        foundAccount = self.__accountRepository.findById(accountId)  # 여기서 회원 식별
-
+    # 인터뷰 생성
+    def createInterview(
+        self,
+        accountId,
+        jobCategory,
+        experienceLevel,
+        projectExperience,
+        academicBackground,
+        techStack,
+        companyName
+    ):
+        foundAccount = self.__accountRepository.findById(accountId)
         print(f"인터뷰 생성 서비스 계층 진입")
 
         if not foundAccount:
             raise Exception("해당 accountId에 해당하는 account를 찾을 수 없습니다.")
 
-        # ✅ techStack이 필수: 없거나 빈 리스트면 예외 발생
+        # ✅ techStack이 필수
         if not techStack or not isinstance(techStack, list) or len(techStack) == 0:
             raise ValueError("techStack은 비어 있을 수 없습니다.")
 
-        newInterview = Interview(  # 인터뷰 DB에 정보 저장을 위한 단계 (구조가 조금 바뀔 예정)
+        newInterview = Interview(
             account=foundAccount,
             status=InterviewStatus.IN_PROGRESS.value,
             topic=jobCategory.value if hasattr(jobCategory, 'value') else jobCategory,
             experience_level=experienceLevel.value if hasattr(experienceLevel, 'value') else experienceLevel,
-            project_experience = projectExperience.value if hasattr(projectExperience, 'value') else projectExperience,
-            academic_background = academicBackground.value if hasattr(academicBackground, 'value') else academicBackground,
-            tech_stack = techStack,
-            company_name = companyName.value if hasattr(companyName, 'value') else companyName
+            project_experience=projectExperience.value if hasattr(projectExperience, 'value') else projectExperience,
+            academic_background=academicBackground.value if hasattr(academicBackground, 'value') else academicBackground,
+            tech_stack=techStack,
+            company_name=companyName.value if hasattr(companyName, 'value') else companyName
         )
         print(f"newInterview: {newInterview}")
 
-        savedInterview = self.__interviewRepository.save(newInterview)  # 인터뷰 정보 저장
+        savedInterview = self.__interviewRepository.save(newInterview)
         return savedInterview
 
-
+    # 질문 저장
     def saveQuestion(self, interview_id: int, question: str) -> int | None:
         print(f"📥 [service] Saving question to DB for interviewId={interview_id}")
         return self.__interviewRepository.saveQuestion(interview_id, question)
 
-
-
+    # 인터뷰 목록 조회
     def listInterview(self, accountId, page, pageSize):
         try:
             account = self.__accountRepository.findById(accountId)
             if not account:
                 raise ValueError(f"Account with ID {accountId} not found.")
 
-            paginatedInterviewList = self.__interviewRepository.findInterviewByAccount(account, page, pageSize)
-
+            paginatedInterviewList = self.__interviewRepository.findInterviewByAccount(accountId, page, pageSize)
             total_items = paginatedInterviewList.paginator.count
 
             interviewDataList = [
                 {
                     "id": interview.id,
-                    "topic": interview.topic,  # Updated field
-                    "yearsOfExperience": interview.yearsOfExperience,  # Updated field
-                    "created_at": interview.created_at,  # Included created_at field
+                    "topic": interview.topic,
+                    "created_at": interview.created_at,
+                    # "yearsOfExperience": interview.experience_level  # 필요하다면 변환
                 }
                 for interview in paginatedInterviewList
             ]
@@ -86,10 +91,11 @@ class InterviewServiceImpl(InterviewService):
             print(f"Unexpected error in listInterview: {e}")
             raise
 
+    # 인터뷰 삭제
     def removeInterview(self, accountId, interviewId):
         try:
             interview = self.__interviewRepository.findById(interviewId)
-            if interview is None or str(interview.account.id) != str(accountId):
+            if interview is None or str(interview.account_id) != str(accountId):
                 return {
                     "error": "해당 인터뷰를 찾을 수 없거나 소유자가 일치하지 않습니다.",
                     "success": False
@@ -97,28 +103,21 @@ class InterviewServiceImpl(InterviewService):
 
             result = self.__interviewRepository.deleteById(interviewId)
             if result:
-                return {
-                    "success": True,
-                    "message": "인터뷰가 삭제되었습니다."
-                }
+                return {"success": True, "message": "인터뷰가 삭제되었습니다."}
 
         except Exception as e:
             print(f"Error in InterviewService.removeInterview: {e}")
-            return {
-                "error": "서버 내부 오류",
-                "success": False
-            }
+            return {"error": "서버 내부 오류", "success": False}
 
+    # 답변 저장
     def saveAnswer(self, accountId: int, interviewId: int, questionId: int, answerText: str) -> bool:
         try:
-            # InterviewAnswer 레포지토리를 사용하여 답변 저장
             interviewAnswer = InterviewAnswer(
                 account_id=accountId,
                 interview_id=interviewId,
                 question_id=questionId,
                 answer_text=answerText
             )
-
             result = self.__interviewAnswerRepository.save(interviewAnswer)
             return result is not None
         except Exception as e:

--- a/interview_result/controller/interview_result_controller.py
+++ b/interview_result/controller/interview_result_controller.py
@@ -31,11 +31,20 @@ class InterviewResultController(viewsets.ViewSet):
                 }, status=status.HTTP_400_BAD_REQUEST)
 
             accountId = self.redisCacheService.getValueByKey(userToken)
-            result = self.interviewResultService.saveInterviewResult(accountId)
+
+            # result = self.interviewResultService.saveInterviewResult(accountId)
+            # ✅ InterviewResult 저장 (accountId + interviewId)
+            result = self.interviewResultService.saveInterviewResult(accountId, interviewId)
+
+            # ✅ Interview 테이블의 status도 COMPLETED로 업데이트
+            from interview.entity.interview import Interview
+            Interview.objects.filter(id=interviewId, account_id=accountId).update(status="COMPLETED")
+
 
             return JsonResponse({
                 "message": "면접 완료 기록 저장 성공",
                 "interviewResultId": result.id,
+                "status": "COMPLETED",   # 👈 프론트에서 확인 가능
                 "success": True
             }, status=status.HTTP_200_OK)
 

--- a/interview_result/entity/interview_result.py
+++ b/interview_result/entity/interview_result.py
@@ -7,6 +7,7 @@ class InterviewResult(models.Model):
     id = models.AutoField(primary_key=True)
     # account ForeignKey를 IntegerField로 변경 (ORM 관계 제거)
     account_id = models.IntegerField()
+    interview_id = models.IntegerField()  # ✅ 새로 추가된 필드
 
     # account 속성을 프로퍼티로 구현 (기존 코드와 호환성 유지)
     @property

--- a/interview_result/repository/interview_result_repository_impl.py
+++ b/interview_result/repository/interview_result_repository_impl.py
@@ -53,9 +53,22 @@ class InterviewResultRepositoryImpl(InterviewResultRepository):
 
         return interviewResultQASList
 
-    def saveInterviewResult(self, accountId):
+    # def saveInterviewResult(self, accountId):
+    #     try:
+    #         interviewResult = InterviewResult.objects.create(account_id=accountId)
+    #         print("✅ 면접 완료 기록 저장")
+    #         return interviewResult
+    #     except Exception as e:
+    #         print(f"❌ 오류 발생: {e}")
+    #         raise
+
+    # ✅ 수정된 저장 로직
+    def saveInterviewResult(self, accountId: int, interviewId: int):
         try:
-            interviewResult = InterviewResult.objects.create(account_id=accountId)
+            interviewResult = InterviewResult.objects.create(
+                account_id=accountId,
+                interview_id=interviewId  # ✅ 추가됨
+            )
             print("✅ 면접 완료 기록 저장")
             return interviewResult
         except Exception as e:

--- a/interview_result/service/interview_result_service_impl.py
+++ b/interview_result/service/interview_result_service_impl.py
@@ -23,8 +23,12 @@ class InterviewResultServiceImpl(InterviewResultService):
         return cls.__instance
 
 
-    def saveInterviewResult(self, accountId):
-        return  self.__interviewResultRepository.saveInterviewResult(accountId)
+    # def saveInterviewResult(self, accountId):
+    #     return  self.__interviewResultRepository.saveInterviewResult(accountId)
+
+    # ✅ 수정된 저장 로직
+    def saveInterviewResult(self, accountId: int, interviewId: int):
+        return self.__interviewResultRepository.saveInterviewResult(accountId, interviewId)
 
     def getInterviewResult(self, accountId):
         account = self.__accountRepository.findById(accountId)


### PR DESCRIPTION
- Interview 모델에서 ForeignKey 유사 구조 제거 후 account_id만 유지
  - account 속성을 property로 구현하여 필요 시 Account 조회
- InterviewRepositoryImpl:
  - Interview.objects.filter(account=account) → account_id 기반 조회로 변경
- InterviewServiceImpl:
  - findInterviewByAccount 호출 시 accountId 직접 전달하도록 수정
  - yearsOfExperience 등 존재하지 않는 필드 참조 제거 예정
- InterviewRepository, InterviewService 인터페이스 시그니처 일치화
  - findInterviewByAccount(account) → findInterviewByAccount(account_id: int)
  - saveQuestion 반환타입 bool → int | None 으로 변경
- 일관성 확보를 통해 500 오류 (Cannot resolve keyword 'account') 해결